### PR TITLE
Solving .github/dependabot.yml format error

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   labels:
   - Dependency
 
-- package-ecosystem: python
+- package-ecosystem: pip
   directory: "/importer"
   schedule:
     interval: weekly


### PR DESCRIPTION
The property '#/updates/1/package-ecosystem' value "python" did not match one of the following values